### PR TITLE
fixed missing level parameter in visit()

### DIFF
--- a/src/PHPCR/Util/TraversingItemVisitor.php
+++ b/src/PHPCR/Util/TraversingItemVisitor.php
@@ -148,8 +148,8 @@ abstract class TraversingItemVisitor implements \PHPCR\ItemVisitorInterface {
      */
     public function visit(\PHPCR\ItemInterface $item) {
         if ($item instanceof \PHPCR\PropertyInterface) {
-            $this->entering($item);
-            $this->leaving($item);
+            $this->entering($item, $this->currentLevel);
+            $this->leaving($item, $this->currentLevel);
         } else {
             try {
                 if ($this->breadthFirst === false) {


### PR DESCRIPTION
not sure if this is the correct fix. should it be hardcoded to 0? currentLevel isnt initialized in the properties either.
