### PR TITLE
Adding quotes to literals in expressions of fullsearch at qom2sql converter

### DIFF
--- a/src/PHPCR/Util/QOM/QomToSql2QueryConverter.php
+++ b/src/PHPCR/Util/QOM/QomToSql2QueryConverter.php
@@ -369,8 +369,7 @@ class QomToSql2QueryConverter
             return $this->convertLiteral($literal);
         }
 
-        //TODO: is that correct?
-        return $literal;
+        return "'$literal'";
     }
 
     /**


### PR DESCRIPTION
FulltextSearchInterface accepts strings as second parameter (the search expression):

http://phpcr.github.com/doc/html/phpcr/query/qom/queryobjectmodelfactoryinterface.html#fullTextSearch()

Thus, returning the literal is valid, but it should be enclosed in single quotes according to specification:

```
FullTextSearchExpression ::= BindVariable | ''' FullTextSearchLiteral '''
```
