### PR TITLE
doc cleanups

### DIFF
--- a/src/PHPCR/Lock/LockInterface.php
+++ b/src/PHPCR/Lock/LockInterface.php
@@ -123,7 +123,7 @@ interface LockInterface
      *
      * @return boolean True, if the lock still counts, else false.
      *
-     * @throws RepositoryException if an error occurs
+     * @throws \PHPCR\RepositoryException if an error occurs
      *
      * @api
      */
@@ -163,8 +163,8 @@ interface LockInterface
      * If this lock's time-to-live is not governed by a timer, then this method
      * has no effect.
      *
-     * @throws \PHPCR\Lock\LockException if this Session does not hold the
-     *      correct lock token for this lock.
+     * @throws LockException if this Session does not hold the correct lock
+     *      token for this lock.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
      * @api

--- a/src/PHPCR/Lock/LockManagerInterface.php
+++ b/src/PHPCR/Lock/LockManagerInterface.php
@@ -47,8 +47,8 @@ interface LockManagerInterface extends \Traversable
      *
      * @return void
      *
-     * @throws \PHPCR\Lock\LockException if the specified lock token is already
-     *      held by another Session and the implementation does not support
+     * @throws LockException if the specified lock token is already held by
+     *      another Session and the implementation does not support
      *      simultaneous ownership of open-scoped locks.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
@@ -66,9 +66,9 @@ interface LockManagerInterface extends \Traversable
      * @param string $absPath absolute path of node for which to obtain the
      *      lock.
      *
-     * @return \PHPCR\Lock\LockInterface The applicable Lock object.
+     * @return LockInterface The applicable Lock object.
      *
-     * @throws \PHPCR\Lock\LockException    if no lock applies to this node.
+     * @throws LockException    if no lock applies to this node.
      * @throws \PHPCR\AccessDeniedException if the current session does not
      *      have sufficient access to get the lock.
      * @throws \PHPCR\PathNotFoundException if no node is found at $absPath
@@ -169,11 +169,11 @@ interface LockManagerInterface extends \Traversable
      *      specified, the implementation chooses one (i.e. user name of
      *      current backend authentication credentials)
      *
-     * @return \PHPCR\Lock\LockInterface A Lock object containing a lock token.
+     * @return LockInterface A Lock object containing a lock token.
      *
-     * @throws \PHPCR\Lock\LockException if this node is not mix:lockable or
-     *      this node is already locked or isDeep is true and a descendant node
-     *      of this node already holds a lock.
+     * @throws LockException if this node is not mix:lockable or this node is
+     *      already locked or isDeep is true and a descendant node of this node
+     *      already holds a lock.
      * @throws \PHPCR\AccessDeniedException if this session does not have
      *      sufficient access to lock this node.
      * @throws \PHPCR\InvalidItemStateException if this node has pending
@@ -189,14 +189,14 @@ interface LockManagerInterface extends \Traversable
      * Alternative method to lock with all the options in one configuration class.
      *
      * @param string  $absPath The absolute path of node to be locked
-     * @param \PHPCR\Lock\LockInfoInterface $lockInfo configured with the desired
+     * @param LockInfoInterface $lockInfo configured with the desired
      *      characteristics for this lock.
      *
-     * @return \PHPCR\Lock\LockInterface A Lock object containing a lock token.
+     * @return LockInterface A Lock object containing a lock token.
      *
-     * @throws \PHPCR\Lock\LockException if this node is not mix:lockable or
-     *      this node is already locked or isDeep is true and a descendant node
-     *      of this node already holds a lock.
+     * @throws LockException if this node is not mix:lockable or this node is
+     *      already locked or isDeep is true and a descendant node of this node
+     *      already holds a lock.
      * @throws \PHPCR\AccessDeniedException if this session does not have
      *      sufficient access to lock this node.
      * @throws \PHPCR\InvalidItemStateException if this node has pending
@@ -232,7 +232,7 @@ interface LockManagerInterface extends \Traversable
      *
      * @return void
      *
-     * @throws \PHPCR\Lock\LockException if the current Session does not hold
+     * @throws LockException if the current Session does not hold
      *      the specified lock token.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
@@ -263,7 +263,7 @@ interface LockManagerInterface extends \Traversable
      *
      * @return void
      *
-     * @throws \PHPCR\Lock\LockException If this node does not currently hold a
+     * @throws LockException If this node does not currently hold a
      *      lock or holds a lock for which this Session does not have the
      *      correct lock token.
      * @throws \PHPCR\AccessDeniedException if the current session does not

--- a/src/PHPCR/NodeType/NodeDefinitionTemplateInterface.php
+++ b/src/PHPCR/NodeType/NodeDefinitionTemplateInterface.php
@@ -103,7 +103,7 @@ interface NodeDefinitionTemplateInterface extends \PHPCR\NodeType\NodeDefinition
      *
      * @api
      */
-    public function setRequiredPrimaryTypeNames(Array $requiredPrimaryTypeNames);
+    public function setRequiredPrimaryTypeNames(array $requiredPrimaryTypeNames);
 
     /**
      * Sets the name of the default primary type of this node.

--- a/src/PHPCR/NodeType/NodeTypeInterface.php
+++ b/src/PHPCR/NodeType/NodeTypeInterface.php
@@ -401,7 +401,7 @@ interface NodeTypeInterface extends \PHPCR\NodeType\NodeTypeDefinitionInterface
      * Returns all subtypes of this node type in the node type inheritance
      * hierarchy.
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     * @return \Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
      *      Keys are the node type names, values the corresponding
      *      NodeTypeInterface instances.
      *
@@ -416,7 +416,7 @@ interface NodeTypeInterface extends \PHPCR\NodeType\NodeTypeDefinitionInterface
      * hierarchy, that is, those which actually declared this node type in their
      * list of supertypes.
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     * @return \Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
      *      Keys are the node type names, values the corresponding
      *      NodeTypeInterface instances.
      *
@@ -475,7 +475,7 @@ interface NodeTypeInterface extends \PHPCR\NodeType\NodeTypeDefinitionInterface
      * Otherwise returns false.
      *
      * @param string $propertyName The name of the property
-     * @param mixed  $value        A variable or an array of variables
+     * @param mixed  $value        A value or an array of values
      *
      * @return boolean True if setting propertyName to value is allowed by this
      *      node type, else false.

--- a/src/PHPCR/NodeType/NodeTypeManagerInterface.php
+++ b/src/PHPCR/NodeType/NodeTypeManagerInterface.php
@@ -73,7 +73,7 @@ interface NodeTypeManagerInterface extends \Traversable
     /**
      * Returns an iterator over all available node types (primary and mixin).
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     * @return \Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
      *      Keys are the node type names, values the corresponding
      *      NodeTypeInterface instances.
      *
@@ -86,7 +86,7 @@ interface NodeTypeManagerInterface extends \Traversable
     /**
      * Returns an iterator over all available primary node types.
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     * @return \Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
      *      Keys are the node type names, values the corresponding
      *      NodeTypeInterface instances.
      *
@@ -101,7 +101,7 @@ interface NodeTypeManagerInterface extends \Traversable
      *
      * If none are available, an empty iterator is returned.
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     * @return \Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
      *      Keys are the node type names, values the corresponding
      *      NodeTypeInterface instances.
      *
@@ -204,7 +204,7 @@ interface NodeTypeManagerInterface extends \Traversable
      * @param boolean $allowUpdate whether to fail if node already exists or to
      *      update it.
      *
-     * @return Iterator over the registered node types implementing
+     * @return \Iterator over the registered node types implementing
      *      <b>SeekableIterator</b> and <b>Countable</b>. Keys are the node
      *      type names, values the corresponding NodeTypeInterface instances.
      *

--- a/src/PHPCR/NodeType/NodeTypeTemplateInterface.php
+++ b/src/PHPCR/NodeType/NodeTypeTemplateInterface.php
@@ -116,7 +116,7 @@ interface NodeTypeTemplateInterface extends \PHPCR\NodeType\NodeTypeDefinitionIn
     /**
      * Sets the queryable status of the node type.
      *
-     * @param booolean $queryable Whether this node is queryable.
+     * @param bool $queryable Whether this node is queryable.
      *
      * @return void
      *

--- a/src/PHPCR/NodeType/PropertyDefinitionTemplateInterface.php
+++ b/src/PHPCR/NodeType/PropertyDefinitionTemplateInterface.php
@@ -144,7 +144,7 @@ interface PropertyDefinitionTemplateInterface extends \PHPCR\NodeType\PropertyDe
     /**
      * Sets the queryable status of the property.
      *
-     * @param array operators An array of String constants
+     * @param array $operators An array of String constants
      *      {@link PropertyDefinition::getAvailableQueryOperators()}.
      *
      * @return void

--- a/src/PHPCR/Observation/EventInterface.php
+++ b/src/PHPCR/Observation/EventInterface.php
@@ -127,6 +127,7 @@ interface EventInterface
      * - PERSIST
      *
      * @return integer the type of this event.
+     *
      * @api
      */
     public function getType();
@@ -141,6 +142,7 @@ interface EventInterface
      * @return string The absolute path associated with this event or null.
      *
      * @throws \PHPCR\RepositoryException if an error occurs.
+     *
      * @api
      */
     public function getPath();
@@ -151,6 +153,7 @@ interface EventInterface
      * This is the string returned by SessionInterface::getUserID() of the session that caused the event.
      *
      * @return string The identifier of the user connected to the event.
+     *
      * @api
      */
     public function getUserID();
@@ -165,6 +168,7 @@ interface EventInterface
      * @return string The identifier associated with this event or null.
      *
      * @throws \PHPCR\RepositoryException if an error occurs.
+     *
      * @api
      */
     public function getIdentifier();
@@ -178,6 +182,7 @@ interface EventInterface
      * @return array A list containing parameter information for instances of a NODE_MOVED event.
      *
      * @throws \PHPCR\RepositoryException if an error occurs.
+     *
      * @api
      */
     public function getInfo();
@@ -187,7 +192,9 @@ interface EventInterface
      * ObservationManager bound to the Session that caused the event.
      *
      * @return string                     The user data string.
+     *
      * @throws \PHPCR\RepositoryException if an error occurs.
+     *
      * @api
      */
     public function getUserData();
@@ -202,6 +209,7 @@ interface EventInterface
      * @return integer The date when the change was persisted that caused this event (milliseconds since epoch).
      *
      * @throws \PHPCR\RepositoryException if an error occurs.
+     *
      * @api
      */
     public function getDate();

--- a/src/PHPCR/Observation/EventJournalInterface.php
+++ b/src/PHPCR/Observation/EventJournalInterface.php
@@ -44,7 +44,7 @@ interface EventJournalInterface extends \Countable, \SeekableIterator
      * exception is thrown but the subsequent next() will fail.
      *
      * @param  integer $date Value that represents an offset in milliseconds from the epoch.
-     * @return void
+     *
      * @api
      */
     public function skipTo($date);

--- a/src/PHPCR/Observation/EventListenerInterface.php
+++ b/src/PHPCR/Observation/EventListenerInterface.php
@@ -40,7 +40,7 @@ interface EventListenerInterface
      * This method is called when a bundle of events is dispatched.
      *
      * @param  \Traversable $events The event set received.
-     * @return void
+     *
      * @api
      */
     public function onEvent(\Traversable $events);

--- a/src/PHPCR/Observation/ObservationManagerInterface.php
+++ b/src/PHPCR/Observation/ObservationManagerInterface.php
@@ -65,7 +65,7 @@ interface ObservationManagerInterface extends \Traversable
      * @param EventListenerInterface $listener
      * @param EventFilterInterface   $filter
      *
-     * @throws RepositoryException If an error occurs.
+     * @throws \PHPCR\RepositoryException If an error occurs.
      *
      * @since JCR 2.1
      *

--- a/src/PHPCR/PropertyInterface.php
+++ b/src/PHPCR/PropertyInterface.php
@@ -586,7 +586,7 @@ interface PropertyInterface extends ItemInterface, \Traversable
     /**
      * Returns a String representation of the value of this property.
      *
-     * @return string\array A string representation of the value of this property, or
+     * @return string|array A string representation of the value of this property, or
      *      an array of string for multi-valued properties.
      *
      * @throws ValueFormatException if conversion to a String is not possible

--- a/src/PHPCR/PropertyType.php
+++ b/src/PHPCR/PropertyType.php
@@ -522,7 +522,7 @@ final class PropertyType
                         if (! $value instanceof \DateTime) {
                             throw new RepositoryException('something weird');
                         }
-
+                        /** @var $value \DateTime */
                         return $value->getTimestamp();
                 }
                 if (is_object($value)) {
@@ -543,6 +543,7 @@ final class PropertyType
                             throw new RepositoryException('something weird');
                         }
 
+                        /** @var $value \DateTime */
                         return (double) $value->getTimestamp();
                 }
                 if (is_object($value)) {
@@ -583,6 +584,7 @@ final class PropertyType
                     case self::BOOLEAN:
                         return (boolean) $value;
                     case self::DATE:
+                        /** @var $value \DateTime */
                         return (boolean) $value->getTimestamp();
                     case self::DECIMAL:
                         return (boolean) ((double) $value); // '0' is false too
@@ -678,6 +680,7 @@ final class PropertyType
                     case self::DECIMAL:
                         return (string) $value;
                     case self::DATE:
+                        /** @var $value \DateTime */
                         return (string) $value->getTimestamp();
                 }
                 if (is_object($value)) {

--- a/src/PHPCR/Query/QOM/AndInterface.php
+++ b/src/PHPCR/Query/QOM/AndInterface.php
@@ -37,7 +37,8 @@ interface AndInterface extends ConstraintInterface
     /**
      * Gets the first constraint.
      *
-     * @return \PHPCR\Query\QOM\ConstraintInterface the constraint; non-null
+     * @return ConstraintInterface the constraint; non-null
+     *
      * @api
      */
     public function getConstraint1();
@@ -45,7 +46,8 @@ interface AndInterface extends ConstraintInterface
     /**
      * Gets the second constraint.
      *
-     * @return \PHPCR\Query\QOM\ConstraintInterface the constraint; non-null
+     * @return ConstraintInterface the constraint; non-null
+     *
      * @api
      */
     public function getConstraint2();

--- a/src/PHPCR/Query/QOM/BindVariableValueInterface.php
+++ b/src/PHPCR/Query/QOM/BindVariableValueInterface.php
@@ -35,6 +35,7 @@ interface BindVariableValueInterface extends StaticOperandInterface
      * Gets the name of the bind variable.
      *
      * @return string the bind variable name; non-null
+     *
      * @api
      */
     public function getBindVariableName();

--- a/src/PHPCR/Query/QOM/ComparisonInterface.php
+++ b/src/PHPCR/Query/QOM/ComparisonInterface.php
@@ -78,7 +78,7 @@ interface ComparisonInterface extends ConstraintInterface
      *
      * Gets the first operand.
      *
-     * @return \PHPCR\Query\QOM\DynamicOperandInterface the operand; non-null
+     * @return DynamicOperandInterface the operand; non-null
      *
      * @api
      */
@@ -87,8 +87,7 @@ interface ComparisonInterface extends ConstraintInterface
     /**
      * Gets the operator.
      *
-     * @return string one of
-     *      \PHPCR\Query\QOM\QueryObjectModelConstantsInterface.JCR_OPERATOR_*
+     * @return string one of QueryObjectModelConstantsInterface.JCR_OPERATOR_*
      *
      * @api
      */
@@ -97,7 +96,7 @@ interface ComparisonInterface extends ConstraintInterface
     /**
      * Gets the second operand.
      *
-     * @return \PHPCR\Query\QOM\StaticOperandInterface the operand; non-null
+     * @return StaticOperandInterface the operand; non-null
      *
      * @api
      */

--- a/src/PHPCR/Query/QOM/FullTextSearchInterface.php
+++ b/src/PHPCR/Query/QOM/FullTextSearchInterface.php
@@ -96,8 +96,7 @@ interface FullTextSearchInterface extends ConstraintInterface
     /**
      * Gets the full-text search expression.
      *
-     * @return \PHPCR\Query\QOM\StaticOperandInterface the full-text search
-     *      expression; non-null
+     * @return StaticOperandInterface the full-text search expression; non-null
      *
      * @api
      */

--- a/src/PHPCR/Query/QOM/JoinInterface.php
+++ b/src/PHPCR/Query/QOM/JoinInterface.php
@@ -34,7 +34,7 @@ interface JoinInterface extends SourceInterface
     /**
      * Gets the left node-tuple source.
      *
-     * @return \PHPCR\Query\QOM\SourceInterface the left source; non-null
+     * @return SourceInterface the left source; non-null
      *
      * @api
      */
@@ -43,7 +43,7 @@ interface JoinInterface extends SourceInterface
     /**
      * Gets the right node-tuple source.
      *
-     * @return \PHPCR\Query\QOM\SourceInterface the right source; non-null
+     * @return SourceInterface the right source; non-null
      *
      * @api
      */
@@ -61,7 +61,7 @@ interface JoinInterface extends SourceInterface
     /**
      * Gets the join condition.
      *
-     * @return JoinCondition the join condition; non-null
+     * @return JoinConditionInterface the join condition; non-null
      *
      * @api
      */

--- a/src/PHPCR/Query/QOM/LengthInterface.php
+++ b/src/PHPCR/Query/QOM/LengthInterface.php
@@ -39,8 +39,7 @@ interface LengthInterface extends DynamicOperandInterface
     /**
      * Gets the property value for which to compute the length.
      *
-     * @return \PHPCR\Query\QOM\PropertyValueInterface the property value;
-     *      non-null
+     * @return PropertyValueInterface the property value; non-null
      *
      * @api
      */

--- a/src/PHPCR/Query/QOM/LiteralInterface.php
+++ b/src/PHPCR/Query/QOM/LiteralInterface.php
@@ -35,6 +35,7 @@ interface LiteralInterface extends StaticOperandInterface
      * Gets the value of the literal.
      *
      * @return string the literal value; non-null
+     *
      * @api
      */
     public function getLiteralValue();

--- a/src/PHPCR/Query/QOM/LowerCaseInterface.php
+++ b/src/PHPCR/Query/QOM/LowerCaseInterface.php
@@ -40,7 +40,8 @@ interface LowerCaseInterface extends DynamicOperandInterface
     /**
      * Gets the operand whose value is converted to a lower-case string.
      *
-     * @return \PHPCR\Query\QOM\DynamicOperandInterface the operand; non-null
+     * @return DynamicOperandInterface the operand; non-null
+     *
      * @api
      */
     public function getOperand();

--- a/src/PHPCR/Query/QOM/NodeLocalNameInterface.php
+++ b/src/PHPCR/Query/QOM/NodeLocalNameInterface.php
@@ -35,6 +35,7 @@ interface NodeLocalNameInterface extends DynamicOperandInterface
      * Gets the name of the selector against which to evaluate this operand.
      *
      * @return string the selector name; non-null
+     *
      * @api
      */
     public function getSelectorName();

--- a/src/PHPCR/Query/QOM/NodeNameInterface.php
+++ b/src/PHPCR/Query/QOM/NodeNameInterface.php
@@ -35,6 +35,7 @@ interface NodeNameInterface extends DynamicOperandInterface
     * Gets the name of the selector against which to evaluate this operand.
     *
     * @return string the selector name; non-null
+    *
     * @api
     */
    public function getSelectorName();

--- a/src/PHPCR/Query/QOM/NotInterface.php
+++ b/src/PHPCR/Query/QOM/NotInterface.php
@@ -36,7 +36,8 @@ interface NotInterface extends ConstraintInterface
     /**
      * Gets the constraint negated by this Not constraint.
      *
-     * @return \PHPCR\Query\QOM\ConstraintInterface the constraint; non-null
+     * @return ConstraintInterface the constraint; non-null
+     *
      * @api
      */
     public function getConstraint();

--- a/src/PHPCR/Query/QOM/OrInterface.php
+++ b/src/PHPCR/Query/QOM/OrInterface.php
@@ -40,7 +40,7 @@ interface OrInterface extends ConstraintInterface
     /**
      * Gets the first constraint.
      *
-     * @return \PHPCR\Query\QOM\ConstraintInterface the constraint; non-null
+     * @return ConstraintInterface the constraint; non-null
      *
      * @api
      */
@@ -49,7 +49,7 @@ interface OrInterface extends ConstraintInterface
     /**
      * Gets the second constraint.
      *
-     * @return \PHPCR\Query\QOM\ConstraintInterface the constraint; non-null
+     * @return ConstraintInterface the constraint; non-null
      *
      * @api
      */

--- a/src/PHPCR/Query/QOM/OrderingInterface.php
+++ b/src/PHPCR/Query/QOM/OrderingInterface.php
@@ -60,7 +60,8 @@ interface OrderingInterface
     /**
      * The operand by which to order.
      *
-     * @return \PHPCR\Query\QOM\DynamicOperandInterface the operand; non-null
+     * @return DynamicOperandInterface the operand; non-null
+     *
      * @api
      */
     public function getOperand();
@@ -70,6 +71,7 @@ interface OrderingInterface
      *
      * @return string either QueryObjectModelConstants.JCR_ORDER_ASCENDING or
      *      QueryObjectModelConstants.JCR_ORDER_DESCENDING
+     *
      * @api
      */
     public function getOrder();

--- a/src/PHPCR/Query/QOM/PropertyExistenceInterface.php
+++ b/src/PHPCR/Query/QOM/PropertyExistenceInterface.php
@@ -38,6 +38,7 @@ interface PropertyExistenceInterface extends ConstraintInterface
      * Gets the name of the selector against which to apply this constraint.
      *
      * @return string the selector name; non-null
+     *
      * @api
      */
     public function getSelectorName();
@@ -46,6 +47,7 @@ interface PropertyExistenceInterface extends ConstraintInterface
      * Gets the name of the property.
      *
      * @return string the property name; non-null
+     *
      * @api
      */
     public function getPropertyName();

--- a/src/PHPCR/Query/QOM/PropertyValueInterface.php
+++ b/src/PHPCR/Query/QOM/PropertyValueInterface.php
@@ -43,6 +43,7 @@ interface PropertyValueInterface extends DynamicOperandInterface
      * Gets the name of the selector against which to evaluate this operand.
      *
      * @return string the selector name; non-null
+     *
      * @api
      */
     public function getSelectorName();
@@ -51,6 +52,7 @@ interface PropertyValueInterface extends DynamicOperandInterface
      * Gets the name of the property.
      *
      * @return string the property name; non-null
+     *
      * @api
      */
     public function getPropertyName();

--- a/src/PHPCR/Query/QOM/QueryObjectModelFactoryInterface.php
+++ b/src/PHPCR/Query/QOM/QueryObjectModelFactoryInterface.php
@@ -44,16 +44,15 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * See the individual QOM factory methods for the validity criteria of each
      * query element.
      *
-     * @param \PHPCR\Query\QOM\SourceInterface $source the Selector or the
-     *      node-tuple Source; non-null
-     * @param \PHPCR\Query\QOM\ConstraintInterface $constraint the constraint,
-     *      or null if none
+     * @param SourceInterface $source the Selector or the node-tuple Source;
+     *      non-null
+     * @param ConstraintInterface $constraint the constraint, or null if none
      * @param array $orderings zero (empty array) or more instances of Ordering
      * @param array $columns   the array of Column definitions to return in the
      *      result. empty array is equivalent to the * in SQL2, meaning some
      *      fields.
      *
-     * @return \PHPCR\Query\QOM\QueryObjectModelInterface the query; non-null
+     * @return QueryObjectModelInterface the query; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -64,8 +63,8 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function createQuery(\PHPCR\Query\QOM\SourceInterface $source,
-                         \PHPCR\Query\QOM\ConstraintInterface $constraint = null,
+    public function createQuery(SourceInterface $source,
+                         ConstraintInterface $constraint = null,
                          array $orderings = array(),
                          array $columns = array());
 
@@ -85,7 +84,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * @param string $nodeTypeName the name of the required node type; non-null
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\SelectorInterface the selector; non-null
+     * @return SelectorInterface the selector; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -102,15 +101,12 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * The query is invalid if $left is the same source as $right.
      *
-     * @param \PHPCR\Query\QOM\SourceInterface $left the left node-tuple
-     *      source; non-null
-     * @param \PHPCR\Query\QOM\SourceInterface $right the right node-tuple
-     *      source; non-null
-     * @param string                                  $joinType      one of QueryObjectModelConstants.JCR_JOIN_TYPE_*
-     * @param \PHPCR\Query\QOM\JoinConditionInterface $joinCondition the join
-     *      condition; non-null
+     * @param SourceInterface        $left          the left node-tuple source; non-null
+     * @param SourceInterface        $right         the right node-tuple source; non-null
+     * @param string                 $joinType      one of QueryObjectModelConstants.JCR_JOIN_TYPE_*
+     * @param JoinConditionInterface $joinCondition the join condition; non-null
      *
-     * @return \PHPCR\Query\QOM\JoinInterface the join; non-null
+     * @return JoinInterface the join; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -120,8 +116,8 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function join(\PHPCR\Query\QOM\SourceInterface $left, \PHPCR\Query\QOM\SourceInterface $right,
-                         $joinType, \PHPCR\Query\QOM\JoinConditionInterface $joinCondition);
+    public function join(SourceInterface $left, SourceInterface $right,
+                         $joinType, JoinConditionInterface $joinCondition);
 
     /**
      * Tests whether the value of a property in a first selector is equal to
@@ -148,8 +144,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * @param string $property2Name the property name in the second selector;
      *       non-null
      *
-     * @return \PHPCR\Query\QOM\EquiJoinConditionInterface the constraint;
-     *      non-null
+     * @return EquiJoinConditionInterface the constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -181,7 +176,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * @param string $selector2Path the path relative to the second selector;
      *      non-null
      *
-     * @return \PHPCR\Query\QOM\SameNodeJoinConditionInterface the constraint;
+     * @return SameNodeJoinConditionInterface the constraint;
      *      non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
@@ -209,8 +204,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * @param string $parentSelectorName the name of the parent selector;
      *      non-null
      *
-     * @return \PHPCR\Query\QOM\ChildNodeJoinConditionInterface the constraint;
-     *      non-null
+     * @return ChildNodeJoinConditionInterface the constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -238,8 +232,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * @param string $ancestorSelectorName the name of the ancestor selector;
      *      non-null
      *
-     * @return \PHPCR\Query\QOM\DescendantNodeJoinConditionInterface the
-     *      constraint; non-null
+     * @return DescendantNodeJoinConditionInterface the constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -254,12 +247,10 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
     /**
      * Performs a logical conjunction of two other constraints.
      *
-     * @param \PHPCR\Query\QOM\ConstraintInterface $constraint1 the first
-     *      constraint; non-null
-     * @param \PHPCR\Query\QOM\ConstraintInterface $constraint2 the second
-     *      constraint; non-null
+     * @param ConstraintInterface $constraint1 the first constraint; non-null
+     * @param ConstraintInterface $constraint2 the second constraint; non-null
      *
-     * @return \PHPCR\Query\QOM\AndInterface the And constraint; non-null
+     * @return AndInterface the And constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -269,18 +260,16 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function andConstraint(\PHPCR\Query\QOM\ConstraintInterface $constraint1,
-                         \PHPCR\Query\QOM\ConstraintInterface $constraint2);
+    public function andConstraint(ConstraintInterface $constraint1,
+                         ConstraintInterface $constraint2);
 
     /**
      * Performs a logical disjunction of two other constraints.
      *
-     * @param \PHPCR\Query\QOM\ConstraintInterface $constraint1 the first
-     *      constraint; non-null
-     * @param \PHPCR\Query\QOM\ConstraintInterface $constraint2 the second
-     *      constraint; non-null
+     * @param ConstraintInterface $constraint1 the first constraint; non-null
+     * @param ConstraintInterface $constraint2 the second constraint; non-null
      *
-     * @return \PHPCR\Query\QOM\OrInterface the Or constraint; non-null
+     * @return OrInterface the Or constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -291,16 +280,16 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function orConstraint(\PHPCR\Query\QOM\ConstraintInterface $constraint1,
-                        \PHPCR\Query\QOM\ConstraintInterface $constraint2);
+    public function orConstraint(ConstraintInterface $constraint1,
+                        ConstraintInterface $constraint2);
 
     /**
      * Performs a logical negation of another constraint.
      *
-     * @param \PHPCR\Query\QOM\ConstraintInterface $constraint the constraint
-     *      to be negated; non-null
+     * @param ConstraintInterface $constraint the constraint to be negated;
+     *      non-null
      *
-     * @return \PHPCR\Query\QOM\NotInterface the Not constraint; non-null
+     * @return NotInterface the Not constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -310,17 +299,15 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function notConstraint(\PHPCR\Query\QOM\ConstraintInterface $constraint);
+    public function notConstraint(ConstraintInterface $constraint);
 
     /**
      * Filters node-tuples based on the outcome of a binary operation.
      *
-     * @param \PHPCR\Query\QOM\DynamicOperandInterface $operand1 the first
-     *      operand; non-null
+     * @param DynamicOperandInterface $operand1 the first operand; non-null
      * @param string $operator the operator; one of
      *      QueryObjectModelConstants.JCR_OPERATOR_*
-     * @param \PHPCR\Query\QOM\StaticOperandInterface $operand2 the second
-     *      operand; non-null
+     * @param StaticOperandInterface $operand2 the second operand; non-null
      *
      * @return \PHPCR\Query\QOM\ComparisonInterface the constraint; non-null
      *
@@ -332,8 +319,8 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function comparison(\PHPCR\Query\QOM\DynamicOperandInterface $operand1, $operator,
-                               \PHPCR\Query\QOM\StaticOperandInterface $operand2);
+    public function comparison(DynamicOperandInterface $operand1, $operator,
+                               StaticOperandInterface $operand2);
 
     /**
      * Tests the existence of a property in the specified or default selector.
@@ -346,8 +333,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * @param string $propertyName the property name; non-null
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\PropertyExistenceInterface the constraint;
-     *      non-null
+     * @return PropertyExistenceInterface the constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -380,8 +366,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *      non-null
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\FullTextSearchInterface the constraint;
-     *      non-null
+     * @return FullTextSearchInterface the constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -465,8 +450,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * @param string $path         an absolute path; non-null
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\DescendantNodeInterface the constraint;
-     *      non-null
+     * @return DescendantNodeInterface the constraint; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -489,7 +473,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      * @param string $propertyName the property name; non-null
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\PropertyValueInterface the operand; non-null
+     * @return PropertyValueInterface the operand; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if the query is invalid
      * @throws \PHPCR\RepositoryException         if the operation otherwise fails
@@ -501,10 +485,10 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
     /**
      * Evaluates to the length (or lengths, if multi-valued) of a property.
      *
-     * @param \PHPCR\Query\QOM\PropertyValueInterface $propertyValue the
-     *      property value for which to compute the length; non-null
+     * @param PropertyValueInterface $propertyValue the property value for
+     *      which to compute the length; non-null
      *
-     * @return \PHPCR\Query\QOM\LengthInterface the operand; non-null
+     * @return LengthInterface the operand; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -514,7 +498,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function length(\PHPCR\Query\QOM\PropertyValueInterface $propertyValue);
+    public function length(PropertyValueInterface $propertyValue);
 
     /**
      * Evaluates to a NAME value equal to the prefix-qualified name of a node
@@ -525,7 +509,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\NodeNameInterface the operand; non-null
+     * @return NodeNameInterface the operand; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -546,7 +530,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\NodeLocalNameInterface the operand; non-null
+     * @return NodeLocalNameInterface the operand; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if the query is invalid
      * @throws \PHPCR\RepositoryException         if the operation otherwise fails
@@ -564,7 +548,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\FullTextSearchScoreInterface the operand;
+     * @return FullTextSearchScoreInterface the operand;
      *      non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
@@ -578,12 +562,13 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
     public function fullTextSearchScore($selectorName = null);
 
     /**
-     * Evaluates to the lower-case string value (or values, if multi-valued) of an operand.
+     * Evaluates to the lower-case string value (or values, if multi-valued) of
+     * an operand.
      *
-     * @param \PHPCR\Query\QOM\DynamicOperandInterface $operand the operand
-     *      whose value is converted to a lower-case string; non-null
+     * @param DynamicOperandInterface $operand the operand whose value is
+     *      converted to a lower-case string; non-null
      *
-     * @return \PHPCR\Query\QOM\LowerCaseInterface the operand; non-null
+     * @return LowerCaseInterface the operand; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -593,16 +578,16 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function lowerCase(\PHPCR\Query\QOM\DynamicOperandInterface $operand);
+    public function lowerCase(DynamicOperandInterface $operand);
 
     /**
      * Evaluates to the upper-case string value (or values, if multi-valued) of
      * an operand.
      *
-     * @param \PHPCR\Query\QOM\DynamicOperandInterface $operand the operand
-     *      whose value is converted to a upper-case string; non-null
+     * @param DynamicOperandInterface $operand the operand whose value is
+     *      converted to a upper-case string; non-null
      *
-     * @return \PHPCR\Query\QOM\UpperCaseInterface the operand; non-null
+     * @return UpperCaseInterface the operand; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -612,7 +597,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @api
      */
-    public function upperCase(\PHPCR\Query\QOM\DynamicOperandInterface $operand);
+    public function upperCase(DynamicOperandInterface $operand);
 
     /**
      * Evaluates to the value of a bind variable.
@@ -621,8 +606,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @param string $bindVariableName the bind variable name; non-null
      *
-     * @return \PHPCR\Query\QOM\BindVariableValueInterface the operand;
-     *      non-null
+     * @return BindVariableValueInterface the operand; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if a particular validity test
      *      is possible on this method, the implementation chooses to perform
@@ -658,34 +642,34 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * The query is invalid if $operand does not evaluate to a scalar value.
      *
-     * @param \PHPCR\Query\QOM\DynamicOperandInterface $operand the operand by
-     *      which to order; non-null
+     * @param DynamicOperandInterface $operand the operand by which to order;
+     *      non-null
      *
-     * @return \PHPCR\Query\QOM\OrderingInterface the ordering
+     * @return OrderingInterface the ordering
      *
      * @throws \PHPCR\Query\InvalidQueryException if the query is invalid
      * @throws \PHPCR\RepositoryException         if the operation otherwise fails
      *
      * @api
      */
-    public function ascending(\PHPCR\Query\QOM\DynamicOperandInterface $operand);
+    public function ascending(DynamicOperandInterface $operand);
 
     /**
      * Orders by the value of the specified operand, in descending order.
      *
      * The query is invalid if $operand does not evaluate to a scalar value.
      *
-     * @param \PHPCR\Query\QOM\DynamicOperandInterface $operand the operand by
-     *      which to order; non-null
+     * @param DynamicOperandInterface $operand the operand by which to order;
+     *      non-null
      *
-     * @return \PHPCR\Query\QOM\OrderingInterface the ordering
+     * @return OrderingInterface the ordering
      *
      * @throws \PHPCR\Query\InvalidQueryException if the query is invalid
      * @throws \PHPCR\RepositoryException         if the operation otherwise fails
      *
      * @api
      */
-    public function descending(\PHPCR\Query\QOM\DynamicOperandInterface $operand);
+    public function descending(DynamicOperandInterface $operand);
 
     /**
      * Identifies a property in the specified or default selector to include in
@@ -715,7 +699,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *      is null
      * @param string $selectorName the selector name; non-null
      *
-     * @return \PHPCR\Query\QOM\ColumnInterface the column; non-null
+     * @return ColumnInterface the column; non-null
      *
      * @throws \PHPCR\Query\InvalidQueryException if the query has no default
      *      selector or is otherwise invalid

--- a/src/PHPCR/Query/QOM/QueryObjectModelInterface.php
+++ b/src/PHPCR/Query/QOM/QueryObjectModelInterface.php
@@ -63,7 +63,8 @@ interface QueryObjectModelInterface extends \PHPCR\Query\QueryInterface
     /**
      * Gets the node-tuple source for this query.
      *
-     * @return \PHPCR\Query\QOM\SourceInterface the node-tuple source; non-null
+     * @return SourceInterface the node-tuple source; non-null
+     *
      * @api
     */
     public function getSource();
@@ -71,8 +72,7 @@ interface QueryObjectModelInterface extends \PHPCR\Query\QueryInterface
     /**
      * Gets the constraint for this query.
      *
-     * @return \PHPCR\Query\QOM\ConstraintInterface the constraint, or null if
-     *      none
+     * @return ConstraintInterface the constraint, or null if none
      *
      * @api
     */

--- a/src/PHPCR/Query/QOM/UpperCaseInterface.php
+++ b/src/PHPCR/Query/QOM/UpperCaseInterface.php
@@ -40,7 +40,7 @@ interface UpperCaseInterface extends DynamicOperandInterface
     /**
      * Gets the operand whose value is converted to a upper-case string.
      *
-     * @return \PHPCR\Query\QOM\DynamicOperandInterface the operand; non-null
+     * @return DynamicOperandInterface the operand; non-null
      * @api
      */
     public function getOperand();

--- a/src/PHPCR/Query/QueryInterface.php
+++ b/src/PHPCR/Query/QueryInterface.php
@@ -78,10 +78,11 @@ interface QueryInterface
     /**
      * Executes this query and returns a QueryResult object.
      *
-     * @return \PHPCR\Query\QueryResultInterface a QueryResult object
+     * @return QueryResultInterface a QueryResult object
      *
-     * @throws \PHPCR\Query\InvalidQueryException if the query contains an unbound variable.
-     * @throws \PHPCR\RepositoryException         if an error occurs
+     * @throws InvalidQueryException      if the query contains an unbound variable.
+     * @throws \PHPCR\RepositoryException if an error occurs
+     *
      * @api
      */
     public function execute();

--- a/src/PHPCR/Query/QueryManagerInterface.php
+++ b/src/PHPCR/Query/QueryManagerInterface.php
@@ -43,10 +43,10 @@ interface QueryManagerInterface
      * @param string $statement The query statement to be executed.
      * @param string $language  The language of the query to be created.
      *
-     * @return \PHPCR\Query\QueryInterface a Query object
+     * @return QueryInterface a Query object
      *
-     * @throws \PHPCR\Query\InvalidQueryException if the query statement is
-     *      syntactically invalid or the specified language is not supported
+     * @throws InvalidQueryException if the query statement is syntactically
+     *      invalid or the specified language is not supported
      * @throws \PHPCR\RepositoryException if another error occurs
      *
      * @api
@@ -75,10 +75,10 @@ interface QueryManagerInterface
      * @param \PHPCR\NodeInterface $node a persisted query (that is, a node of
      *      type nt:query).
      *
-     * @return \PHPCR\Query\QueryInterface a Query object.
+     * @return QueryInterface a Query object.
      *
-     * @throws \PHPCR\Query\InvalidQueryException If node is not a valid
-     *      persisted query (that is, a node of type nt:query).
+     * @throws InvalidQueryException If node is not a valid persisted query
+     *      (that is, a node of type nt:query).
      * @throws \PHPCR\RepositoryException if another error occurs
      *
      * @api

--- a/src/PHPCR/Retention/RetentionManagerInterface.php
+++ b/src/PHPCR/Retention/RetentionManagerInterface.php
@@ -108,7 +108,7 @@ interface RetentionManagerInterface
      *
      * @api
      */
-    public function removeHold($absPath, \PHPCR\Retention\HoldInterface $hold);
+    public function removeHold($absPath, HoldInterface $hold);
 
     /**
      * Gets the retention poilcy of a node identified by its path.
@@ -119,9 +119,8 @@ interface RetentionManagerInterface
      *
      * @param string $absPath an absolute path to an existing node.
      *
-     * @return \PHPCR\Retention\RetentionPolicyInterface The retention policy
-     *      that applies to the existing node at $absPath or null if no policy
-     *      applies.
+     * @return RetentionPolicyInterface The retention policy that applies to
+     *      the existing node at $absPath or null if no policy applies.
      *
      * @throws \PHPCR\PathNotFoundException if no node at $absPath exists or
      *      the session does not have sufficient access to retrieve the node.

--- a/src/PHPCR/Security/AccessControlListInterface.php
+++ b/src/PHPCR/Security/AccessControlListInterface.php
@@ -41,7 +41,7 @@ namespace PHPCR\Security;
  *
  * @api
  */
-interface AccessControlListInterface extends \PHPCR\Security\AccessControlPolicyInterface, \Traversable
+interface AccessControlListInterface extends AccessControlPolicyInterface, \Traversable
 {
     /**
      * Returns all access control entries present with this policy.
@@ -80,9 +80,9 @@ interface AccessControlListInterface extends \PHPCR\Security\AccessControlPolicy
      *
      * @return boolean true if this policy was modify; false otherwise.
      *
-     * @throws \PHPCR\Security\AccessControlException if the specified
-     *      principal or any of the privileges does not exist or if some other
-     *      access control related exception occurs.
+     * @throws AccessControlException if the specified principal or any of the
+     *      privileges does not exist or if some other access control related
+     *      exception occurs.
      * @throws \PHPCR\RepositoryException - if another error occurs.
      *
      * @api
@@ -97,16 +97,16 @@ interface AccessControlListInterface extends \PHPCR\Security\AccessControlPolicy
      * re-assigned to a node by calling AccessControlManagerInterface::setPolicy()
      * and save is performed.
      *
-     * @param \PHPCR\Security\AccessControlEntryInterface $ace the access
-     *      control entry to be removed.
+     * @param AccessControlEntryInterface $ace the access control entry to be
+     *      removed.
      *
      * @return void
      *
-     * @throws \PHPCR\Security\AccessControlException if the specified entry is
-     *      not present on the specified node.
+     * @throws AccessControlException if the specified entry is not present on
+     *      the specified node.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
      * @api
      */
-    public function removeAccessControlEntry(\PHPCR\Security\AccessControlEntryInterface $ace);
+    public function removeAccessControlEntry(AccessControlEntryInterface $ace);
 }

--- a/src/PHPCR/Security/AccessControlManagerInterface.php
+++ b/src/PHPCR/Security/AccessControlManagerInterface.php
@@ -71,11 +71,10 @@ interface AccessControlManagerInterface
      *
      * @param string $privilegeName The name of an existing privilege.
      *
-     * @return \PHPCR\Security\PrivilegeInterface the Privilege with the
-     *      specified $privilegeName.
+     * @return PrivilegeInterface the Privilege with the specified name.
      *
-     * @throws \PHPCR\Security\AccessControlException if no privilege with the
-     *      specified name exists.
+     * @throws AccessControlException if no privilege with the specified name
+     *      exists.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
      * @api
@@ -259,16 +258,15 @@ interface AccessControlManagerInterface
      * @param string|null $absPath The absolute path to the node to which
      *      privileges are to be set or null for the repository as a whole.
 
-     * @param \PHPCR\Security\AccessControlPolicyInterface $policy The
-     *      AccessControlPolicy to be applied.
+     * @param AccessControlPolicyInterface $policy The AccessControlPolicy to
+     *      be applied.
      *
      * @return void
      *
      * @throws \PHPCR\PathNotFoundException if $absPath is non-null and no node
      *      at $absPath exists or the session does not have sufficient access
      *      to retrieve a node at that location.
-     * @throws \PHPCR\Security\AccessControlException if the policy is not
-     *      applicable.
+     * @throws AccessControlException if the policy is not applicable.
      * @throws \PHPCR\AccessDeniedException if the session lacks
      *      MODIFY_ACCESS_CONTROL privilege for $absPath.
      * @throws \PHPCR\Lock\LockException if a lock prevents the assignment and
@@ -281,7 +279,7 @@ interface AccessControlManagerInterface
      *
      * @api
      */
-    public function setPolicy($absPath, \PHPCR\Security\AccessControlPolicyInterface $policy);
+    public function setPolicy($absPath, AccessControlPolicyInterface $policy);
 
     /**
      * Removes the specified AccessControlPolicy from the object specified by
@@ -298,16 +296,15 @@ interface AccessControlManagerInterface
      * @param string|null $absPath The absolute path to the node from which
      *      privileges are removed or null for the repository as a whole.
 
-     * @param \PHPCR\Security\AccessControlPolicyInterface $policy the policy
-     *      to be removed.
+     * @param AccessControlPolicyInterface $policy the policy to be removed.
      *
      * @return void
      *
      * @throws \PHPCR\PathNotFoundException if $absPath is non-null and no node
      *      at $absPath exists or the session does not have sufficient access
      *      to retrieve a node at that location.
-     * @throws \PHPCR\Security\AccessControlException if the policy to remove
-     *      does not exist at the node at absPath.
+     * @throws AccessControlException if the policy to remove does not exist at
+     *      the node at absPath.
      * @throws \PHPCR\AccessDeniedException if the session lacks
      *      MODIFY_ACCESS_CONTROL privilege for the absPath node.
      * @throws \PHPCR\Lock\LockException if $absPath specifies a locked node
@@ -320,5 +317,5 @@ interface AccessControlManagerInterface
      *
      * @api
      */
-    public function removePolicy($absPath, \PHPCR\Security\AccessControlPolicyInterface $policy);
+    public function removePolicy($absPath, AccessControlPolicyInterface $policy);
 }

--- a/src/PHPCR/Security/NamedAccessControlPolicyInterface.php
+++ b/src/PHPCR/Security/NamedAccessControlPolicyInterface.php
@@ -33,7 +33,7 @@ namespace PHPCR\Security;
  *
  * @api
  */
-interface NamedAccessControlPolicyInterface extends \PHPCR\Security\AccessControlPolicyInterface
+interface NamedAccessControlPolicyInterface extends AccessControlPolicyInterface
 {
     /**
      * Returns the name of the access control policy, which is JCR name and

--- a/src/PHPCR/Transaction/UserTransactionInterface.php
+++ b/src/PHPCR/Transaction/UserTransactionInterface.php
@@ -97,8 +97,8 @@ interface UserTransactionInterface
      *
      * @return void
      *
-     * @throws \PHPCR\Transaction\RollbackException Thrown to indicate that the
-     *      transaction has been rolled back rather than committed.
+     * @throws RollbackException Thrown to indicate that the transaction has
+     *      been rolled back rather than committed.
      * @throws \PHPCR\AccessDeniedException Thrown to indicate that the
      *      session is not allowed to commit the transaction.
      * @throws \LogicException Thrown if the current

--- a/src/PHPCR/Version/ActivityViolationException.php
+++ b/src/PHPCR/Version/ActivityViolationException.php
@@ -36,6 +36,6 @@ namespace PHPCR\Version;
  *
  * @api
  */
-class ActivityViolationException extends \PHPCR\Version\VersionException
+class ActivityViolationException extends VersionException
 {
 }

--- a/src/PHPCR/Version/LabelExistsVersionException.php
+++ b/src/PHPCR/Version/LabelExistsVersionException.php
@@ -31,6 +31,6 @@ namespace PHPCR\Version;
  *
  * @api
  */
-class LabelExistsVersionException extends \PHPCR\Version\VersionException
+class LabelExistsVersionException extends VersionException
 {
 }

--- a/src/PHPCR/Version/VersionHistoryInterface.php
+++ b/src/PHPCR/Version/VersionHistoryInterface.php
@@ -52,7 +52,7 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
     /**
      * Returns the root version of this version history.
      *
-     * @return \PHPCR\Version\VersionInterface a Version object.
+     * @return VersionInterface a Version object.
      *
      * @throws \PHPCR\RepositoryException if an error occurs.
      *
@@ -80,7 +80,7 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      * equivalent to returning all versions in the version history in order from
      * oldest to newest.
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and
+     * @return \Iterator implementing <b>SeekableIterator</b> and
      *      <b>Countable</b>. Values are the VersionInterface instances. Keys
      *      are the version names.
      *
@@ -96,7 +96,7 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      * returned in order of creation date, from oldest to newest. Otherwise the
      * order of the returned versions is implementation-dependent.
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and
+     * @return \Iterator implementing <b>SeekableIterator</b> and
      *      <b>Countable</b>. Values are the VersionInterface instances. Keys
      *      are the version names.
      *
@@ -110,7 +110,7 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      * This method returns all the frozen nodes of all the versions in this
      * verison history in the same order as getAllLinearVersions().
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and
+     * @return \Iterator implementing <b>SeekableIterator</b> and
      *      <b>Countable</b>. Values are the NodeInterface instances. Keys
      *      are the version names
      *
@@ -126,7 +126,7 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      * nodes will be the order of their creation. Under full versioning the
      * order is implementation-dependent.
      *
-     * @return Iterator implementing <b>SeekableIterator</b> and
+     * @return \Iterator implementing <b>SeekableIterator</b> and
      *      <b>Countable</b>. Values are the NodeInterface instances. Keys
      *      are the version names
      *
@@ -142,10 +142,10 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      *
      * @param string $versionName a version name
      *
-     * @return \PHPCR\Version\VersionInterface a Version object.
+     * @return VersionInterface a Version object.
      *
-     * @throws \PHPCR\Version\VersionException if the specified version is not
-     *      in this version history.
+     * @throws VersionException if the specified version is not in this version
+     *      history.
      * @throws \PHPCR\RepositoryException if an error occurs.
      *
      * @api
@@ -158,10 +158,10 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      *
      * @param string $label a version label
      *
-     * @return \PHPCR\Version\VersionInterface a Version object.
+     * @return VersionInterface a Version object.
      *
-     * @throws \PHPCR\Version\VersionException if the specified label is not in
-     *      this version history.
+     * @throws VersionException if the specified label is not in this version
+     *      history.
      * @throws \PHPCR\RepositoryException if an error occurs.
      *
      * @api
@@ -207,12 +207,12 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      *
      * @return void
      *
-     * @throws \PHPCR\Version\LabelExistsVersionException if moveLabel is
-     *      false, and an attempt is made to add a label that already exists in
-     *      this version history
-     * @throws \PHPCR\Version\VersionException if the specified version does
-     *      not exist in this version history or if the specified version is
-     *      the root version (jcr:rootVersion).
+     * @throws LabelExistsVersionException if moveLabel is false, and an
+     *      attempt is made to add a label that already exists in this version
+     *      history
+     * @throws VersionException if the specified version does not exist in this
+     *      version history or if the specified version is the root version
+     *      (jcr:rootVersion).
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
      * @api
@@ -235,8 +235,8 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      *
      * @return void
      *
-     * @throws \PHPCR\Version\VersionException if the name label does not exist
-     *      in this version history.
+     * @throws VersionException if the name label does not exist in this
+     *      version history.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
      * @api
@@ -254,12 +254,12 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      *
      * @param string $label a version label. A JCR name in either extended or
      *      qualified form.
-     * @param \PHPCR\Version\VersionInterface $version a Version object
+     * @param VersionInterface $version a Version object
      *
      * @return boolean a boolean.
      *
-     * @throws \PHPCR\Version\VersionException if the specified version is not
-     *      of this version history.
+     * @throws VersionException if the specified version is not of this version
+     *      history.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
      * @api
@@ -280,8 +280,8 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      * @return array a string array containing all the labels of the (given)
      *      version (history)
      *
-     * @throws \PHPCR\Version\VersionException if the specified version is not
-     *      in this version history.
+     * @throws VersionException if the specified version is not in this version
+     *      history.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
      * @api
@@ -320,8 +320,8 @@ interface VersionHistoryInterface extends \PHPCR\NodeInterface
      *      Session does not have read access to that REFERENCE property.
      * @throws \PHPCR\UnsupportedRepositoryOperationException if this operation
      *      is not supported by the implementation.
-     * @throws \PHPCR\Version\VersionException if the named version is not in
-     *      this version history.
+     * @throws VersionException if the named version is not in this version
+     *      history.
      * @throws \PHPCR\RepositoryException if another error occurs.
      *
      * @api

--- a/src/PHPCR/Version/VersionInterface.php
+++ b/src/PHPCR/Version/VersionInterface.php
@@ -35,7 +35,7 @@ interface VersionInterface extends \PHPCR\NodeInterface
     /**
      * Returns the VersionHistory that contains this Version
      *
-     * @return \PHPCR\Version\VersionHistoryInterface the VersionHistory that
+     * @return VersionHistoryInterface the VersionHistory that
      *      contains this Version
      *
      * @throws \PHPCR\RepositoryException if an error occurs
@@ -68,7 +68,7 @@ interface VersionInterface extends \PHPCR\NodeInterface
      * Note that under simple versioning the behavior of this method is
      * equivalent to getting the unique successor (if any) of this version.
      *
-     * @return \PHPCR\VersionInterface a Version or null if no linear successor
+     * @return VersionInterface a Version or null if no linear successor
      *      exists.
      *
      * @throws \PHPCR\RepositoryException if an error occurs.
@@ -86,7 +86,7 @@ interface VersionInterface extends \PHPCR\NodeInterface
      * jcr:successors multi-value property in the nt:version node that
      * represents this version.
      *
-     * @return array of \PHPCR\Version\VersionInterface
+     * @return array of VersionInterface
      *
      * @throws \PHPCR\RepositoryException if an error occurs
      *
@@ -105,7 +105,7 @@ interface VersionInterface extends \PHPCR\NodeInterface
      * Note that under simple versioning the behavior of this method is
      * equivalent to getting the unique predecessor (if any) of this version.
      *
-     * @return \PHPCR\Version\VersionInterface a Version or null if no linear
+     * @return VersionInterface a Version or null if no linear
      *      predecessor exists.
      *
      * @throws \PHPCR\RepositoryException if an error occurs.
@@ -124,7 +124,7 @@ interface VersionInterface extends \PHPCR\NodeInterface
      * the nt:version nodes whose jcr:successors property includes a reference
      * to the nt:version node that represents this version.
      *
-     * @return array of \PHPCR\Version\VersionInterface
+     * @return array of VersionInterface
      *
      * @throws \PHPCR\RepositoryException if an error occurs
      *


### PR DESCRIPTION
this is mainly removing the namespace if the target class is in the same namespace and adding namespace where it was missing. the test suite still works and phpstorm also sees no error so i think it should be fine.
