### PR TITLE
JSR_333-67: allow an optional filter in NodeInterface::getNodeNames

### DIFF
--- a/src/PHPCR/NodeInterface.php
+++ b/src/PHPCR/NodeInterface.php
@@ -511,13 +511,19 @@ interface NodeInterface extends ItemInterface, \Traversable
      * If this node has no accessible child nodes, then an empty iterator is
      * returned.
      *
+     * The optional $filter follows the same semantics as the $filter parameter
+     * of NodeInterface::getNodes()
+     *
+     * @param string|array $filter a name pattern or an array of globbing
+     *      strings.
+     *
      * @return \Iterator over all child node names
      *
      * @throws RepositoryException if an error occurs.
      *
      * @since JCR 2.1
      */
-    public function getNodeNames();
+    public function getNodeNames($filter = null);
 
     /**
      * Returns the property at relPath relative to this node.


### PR DESCRIPTION
according to http://java.net/jira/browse/JSR_333-67 and http://java.net/projects/jsr-333/lists/dev/archive/2013-03/message/2

this should be coordinated with #54 to just have one version tag with a BC break.
