### PR TITLE
properly document arrays that are of known types to help IDEs

### DIFF
--- a/src/PHPCR/NodeInterface.php
+++ b/src/PHPCR/NodeInterface.php
@@ -24,6 +24,8 @@
 
 namespace PHPCR;
 
+use PHPCR\NodeType\NodeTypeInterface;
+
 /**
  * The Node interface represents a node in a workspace.
  *
@@ -884,7 +886,7 @@ interface NodeInterface extends ItemInterface, \Traversable
      * supertypes to the primary type hierarchy or through the addition of
      * supertypes to the type hierarchy of any of the declared mixin types.
      *
-     * @return array of \PHPCR\NodeType\NodeTypeInterface objects.
+     * @return NodeTypeInterface[] an array of mixin node types
      *
      * @throws RepositoryException if an error occurs
      *

--- a/src/PHPCR/NodeType/NodeDefinitionInterface.php
+++ b/src/PHPCR/NodeType/NodeDefinitionInterface.php
@@ -48,7 +48,7 @@ interface NodeDefinitionInterface extends \PHPCR\NodeType\ItemDefinitionInterfac
      * object may be acquired (in the form of a NodeDefinitionTemplate) that is
      * not attached to a live NodeType. In such cases this method returns null.
      *
-     * @return \PHPCR\NodeType\NodeTypeInterface An array of NodeType objects.
+     * @return NodeTypeInterface[] An array of NodeType objects.
      *
      * @api
      */
@@ -65,7 +65,7 @@ interface NodeDefinitionInterface extends \PHPCR\NodeType\ItemDefinitionInterfac
      * primary types as set in that template. If that template is a newly-created
      * empty one, then this method will return null.
      *
-     * @return array a String array
+     * @return array the names of the required primary types
      *
      * @api
      */
@@ -84,7 +84,7 @@ interface NodeDefinitionInterface extends \PHPCR\NodeType\ItemDefinitionInterfac
      * object may be acquired (in the form of a NodeDefinitionTemplate) that is
      * not attached to a live NodeType. In such cases this method returns null.
      *
-     * @return \PHPCR\NodeType\NodeTypeInterface A NodeType.
+     * @return NodeTypeInterface A NodeType.
      *
      * @api
      */

--- a/src/PHPCR/NodeType/NodeTypeDefinitionInterface.php
+++ b/src/PHPCR/NodeType/NodeTypeDefinitionInterface.php
@@ -64,7 +64,7 @@ interface NodeTypeDefinitionInterface
      * NodeTypeTemplate, then this method will return an array containing a
      * single string indicating the node type nt:base.
      *
-     * @return array List of names of declared supertypes.
+     * @return array the names of the declared supertypes.
      *
      * @api
      */
@@ -170,7 +170,7 @@ interface NodeTypeDefinitionInterface
      * NodeTypeDefinition object is actually a newly-created empty
      * NodeTypeTemplate, then this method will return null.
      *
-     * @return array An array of PropertyDefinitions.
+     * @return PropertyDefinitionInterface[] An array of PropertyDefinitions.
      *
      * @api
      */
@@ -184,7 +184,7 @@ interface NodeTypeDefinitionInterface
      * NodeTypeDefinition object is actually a newly-created empty
      * NodeTypeTemplate, then this method will return null.
      *
-     * @return array An array of NodeDefinitions.
+     * @return NodeDefinitionInterface[] An array of NodeDefinitions.
      *
      * @api
      */

--- a/src/PHPCR/NodeType/NodeTypeInterface.php
+++ b/src/PHPCR/NodeType/NodeTypeInterface.php
@@ -361,7 +361,7 @@ interface NodeTypeInterface extends \PHPCR\NodeType\NodeTypeDefinitionInterface
      * For primary types apart from nt:base, this list will always
      * include at least nt:base. For mixin types, there is no required supertype.
      *
-     * @return array List of \PHPCR\NodeType\NodeType objects.
+     * @return NodeTypeInterface[] an array of all parent NodeTypes
      *
      * @api
      */
@@ -377,7 +377,8 @@ interface NodeTypeInterface extends \PHPCR\NodeType\NodeTypeDefinitionInterface
      * @see getSupertypes()
      * @see NodeTypeDefinition::getDeclaredSupertypeNames()
      *
-     * @return string[] the names of all supertypes
+     * @return array the names of all supertypes
+     *
      * @since JCR 2.1
      */
     public function getSupertypeNames();
@@ -391,7 +392,8 @@ interface NodeTypeInterface extends \PHPCR\NodeType\NodeTypeDefinitionInterface
      * size 0 or 1. In systems that support multiple inheritance of node
      * types this array may be of size greater than 1.
      *
-     * @return array List of \PHPCR\NodeType\NodeTypeInterface objects.
+     * @return NodeTypeInterface[] an array of NodeTypes that are direct
+     *      parents of this type.
      *
      * @api
      */
@@ -447,8 +449,7 @@ interface NodeTypeInterface extends \PHPCR\NodeType\NodeTypeDefinitionInterface
      * This includes both those property definitions actually declared
      * in this node type and those inherited from the supertypes of this type.
      *
-     * @return array An array of \PHPCR\NodeType\PropertyDefinition containing
-     *      the property definitions.
+     * @return PropertyDefinitionInterface[] an array of property definitions
      *
      * @api
      */
@@ -460,8 +461,7 @@ interface NodeTypeInterface extends \PHPCR\NodeType\NodeTypeDefinitionInterface
      * This includes both those child node definitions actually declared in this
      * node type and those inherited from the supertypes of this node type.
      *
-     * @return array An array of \PHPCR\NodeType\NodeDefinitionInterface containing the
-     *      child node definitions.
+     * @return NodeDefinitionInterface[] An array of child node definitions
      *
      * @api
      */

--- a/src/PHPCR/NodeType/PropertyDefinitionInterface.php
+++ b/src/PHPCR/NodeType/PropertyDefinitionInterface.php
@@ -196,7 +196,7 @@ interface PropertyDefinitionInterface extends \PHPCR\NodeType\ItemDefinitionInte
      * PropertyDefinition object is actually a newly-created empty
      * PropertyDefinitionTemplate, then this method will return null.
      *
-     * @return array a String array.
+     * @return array the value constraint strings
      *
      * @api
      */
@@ -229,7 +229,7 @@ interface PropertyDefinitionInterface extends \PHPCR\NodeType\ItemDefinitionInte
      * PropertyDefinition object is actually a newly-created empty
      * PropertyDefinitionTemplate, then this method will return null.
      *
-     * @return array An array of php values.
+     * @return array An array of mixed php values.
      *
      * @api
      */
@@ -266,7 +266,7 @@ interface PropertyDefinitionInterface extends \PHPCR\NodeType\ItemDefinitionInte
      * JCR defines the comparison operators
      * \PHPCR\Query\QueryObjectModelConstantsInterface::JCR_OPERATOR_*
      *
-     *  An implementation may define additional comparison operators.
+     * An implementation may define additional comparison operators.
      *
      * Note that the set of operators that can appear in this attribute may be
      * limited by implementation-specific constraints that differ across
@@ -280,7 +280,10 @@ interface PropertyDefinitionInterface extends \PHPCR\NodeType\ItemDefinitionInte
      * comparison semantics defined in the specification document (see 3.6.5
      * Comparison of Values).
      *
-     * @return array List of query operators.
+     * @return array an array of query operator constants as defined in
+     *      \PHPCR\Query\QueryObjectModelConstantsInterface
+     *
+     * @see \PHPCR\Query\QueryObjectModelConstantsInterface
      *
      * @api
      */

--- a/src/PHPCR/Query/QOM/QueryObjectModelInterface.php
+++ b/src/PHPCR/Query/QOM/QueryObjectModelInterface.php
@@ -81,7 +81,9 @@ interface QueryObjectModelInterface extends \PHPCR\Query\QueryInterface
     /**
      * Gets the orderings for this query.
      *
-     * @return array a list of zero or more OrderingInterface; non-null
+     * @return OrderingInterface[] an array of the orderings, if no orderings
+     *      defined an empty array.
+     *
      * @api
     */
     public function getOrderings();
@@ -89,7 +91,9 @@ interface QueryObjectModelInterface extends \PHPCR\Query\QueryInterface
     /**
      * Gets the columns for this query.
      *
-     * @return array a list of zero or more ColumnInterface; non-null
+     * @return ColumnInterface[] an array of the columns to get, if none
+     *      specified an empty array.
+     *
      * @api
     */
     public function getColumns();

--- a/src/PHPCR/Query/QueryManagerInterface.php
+++ b/src/PHPCR/Query/QueryManagerInterface.php
@@ -94,7 +94,7 @@ interface QueryManagerInterface
      * may also support other languages including the deprecated languages of
      * JCR 1.0: QueryInterface::XPATH and QueryInterface::SQL.
      *
-     * @return array A list of supported languages by the query.
+     * @return array A list of query languages supported by this repository.
      *
      * @throws \PHPCR\RepositoryException if an error occurs.
      *

--- a/src/PHPCR/Retention/RetentionManagerInterface.php
+++ b/src/PHPCR/Retention/RetentionManagerInterface.php
@@ -39,8 +39,8 @@ interface RetentionManagerInterface
      *
      * @param string $absPath The absolute path to a node.
      *
-     * @return array All hold objects that have been added to the existing node
-     *      at absPath through this API or an empty array if no hold has been
+     * @return HoldInterface[] All holds that have been added to the existing
+     *      node at absPath through this API. Empty array if no hold has been
      *      set.
      *
      * @throws \PHPCR\PathNotFoundException if no node at absPath exists or the

--- a/src/PHPCR/Security/AccessControlEntryInterface.php
+++ b/src/PHPCR/Security/AccessControlEntryInterface.php
@@ -50,7 +50,7 @@ interface AccessControlEntryInterface extends \Traversable
     /**
      * Returns the privileges associated with this access control entry.
      *
-     * @return array an array of Privileges.
+     * @return PrivilegeInterface[] an array of Privileges.
      *
      * @api
      */

--- a/src/PHPCR/Security/AccessControlListInterface.php
+++ b/src/PHPCR/Security/AccessControlListInterface.php
@@ -49,7 +49,8 @@ interface AccessControlListInterface extends AccessControlPolicyInterface, \Trav
      * This method is only guaranteed to return an access control entry object
      * if that access control entry object has been assigned through this API.
      *
-     * @return array all AccessControlEntry objects present with this policy.
+     * @return AccessControlEntryInterface[] an array of all
+     *      AccessControlEntries present with this policy.
      *
      * @throws \PHPCR\RepositoryException - if an error occurs.
      *

--- a/src/PHPCR/Security/AccessControlManagerInterface.php
+++ b/src/PHPCR/Security/AccessControlManagerInterface.php
@@ -55,7 +55,7 @@ interface AccessControlManagerInterface
      * @param string|null $absPath The absolute path to a node the privileges shall
      *      be fetched of.
      *
-     * @return array An array of Privileges.
+     * @return PrivilegeInterface[] An array of Privileges.
      *
      * @throws \PHPCR\PathNotFoundException if $absPath is non-null and either
      *      no node exists at that path or the session does not have sufficient
@@ -140,7 +140,7 @@ interface AccessControlManagerInterface
      * @param string|null $absPath The absolute path to a node the privileges shall
      *      be fetched of or null to fetch non-node privileges.
      *
-     * @return array an array of Privileges.
+     * @return PrivilegeInterface[] an array of Privileges.
      *
      * @throws \PHPCR\PathNotFoundException if $absPath is non-null and no node
      *      at $absPath exists or the session does not have sufficient access
@@ -167,8 +167,8 @@ interface AccessControlManagerInterface
      * @param string|null $absPath The absolute path to a node the privileges shall
      *      be fetched of or null to fetch non-node privileges.
      *
-     * @return array an array of AccessControlPolicy objects or an empty array
-     *      if no policy has been set.
+     * @return AccessControlPolicyInterface[] an array of AccessControlPolicies, if
+     *      no policy has been set the array is empty.
      *
      * @throws \PHPCR\PathNotFoundException if $absPath is non-null and no node
      *      at $absPath exists or the session does not have sufficient access
@@ -195,7 +195,7 @@ interface AccessControlManagerInterface
      * @param string|null $absPath The absolute path to the node of which privileges
      *      are requested or null for non-node privileges.
      *
-     * @return array an array of AccessControlPolicy objects.
+     * @return AccessControlPolicyInterface[] an array of AccessControlPolices.
      *
      * @throws \PHPCR\PathNotFoundException if $absPath is non-null and no node
      *      at $absPath exists or the session does not have sufficient access

--- a/src/PHPCR/Security/PrivilegeInterface.php
+++ b/src/PHPCR/Security/PrivilegeInterface.php
@@ -252,7 +252,7 @@ interface PrivilegeInterface
      * directly contained by the aggregate privilege. Otherwise returns an empty
      * array.
      *
-     * @return array an array of Privileges
+     * @return PrivilegeInterface[] an array of Privileges
      *
      * @api
      */
@@ -264,7 +264,7 @@ interface PrivilegeInterface
      * those, and so on (the transitive closure of privileges contained by this
      * privilege). Otherwise returns an empty array.
      *
-     * @return array an array of Privileges
+     * @return PrivilegeInterface[] an array of Privileges
      *
      * @api
      */

--- a/src/PHPCR/Version/VersionInterface.php
+++ b/src/PHPCR/Version/VersionInterface.php
@@ -86,7 +86,7 @@ interface VersionInterface extends \PHPCR\NodeInterface
      * jcr:successors multi-value property in the nt:version node that
      * represents this version.
      *
-     * @return array of VersionInterface
+     * @return VersionInterface[] an array of Versions
      *
      * @throws \PHPCR\RepositoryException if an error occurs
      *
@@ -124,7 +124,7 @@ interface VersionInterface extends \PHPCR\NodeInterface
      * the nt:version nodes whose jcr:successors property includes a reference
      * to the nt:version node that represents this version.
      *
-     * @return array of VersionInterface
+     * @return VersionInterface[] an array of Versions
      *
      * @throws \PHPCR\RepositoryException if an error occurs
      *


### PR DESCRIPTION
this is no code change, only the `@return array` have been changed to `@return XyInterface[]` where applicable to help modern IDEs recognize interfaces.
