### PR TITLE
improve doc on event journal, drop countable interface

### DIFF
--- a/src/PHPCR/Observation/EventJournalInterface.php
+++ b/src/PHPCR/Observation/EventJournalInterface.php
@@ -26,16 +26,22 @@ namespace PHPCR\Observation;
 
 /**
  * An EventJournal is an extended Iterator that provides the additional
- * method skipTo().
+ * method skipTo(). All elements in this iterator are of type EventInterface.
  *
- * All elements in this iterator are of type EventInterface.
+ * When interacting with the journal, you should first call skipTo or you risk
+ * loading a large amount of events.
  *
  * <b>PHPCR Note:</b> This is the only iterator interface we kept, as it adds
- * additional value (performance).
+ * additional value (performance). This journal is not countable on purpose.
+ * There is a potentially high number of events in the system and counting them
+ * could be very expensive.
+ * seek() is an alias of skipTo()
+ * rewind() should only rewind to the last point set in skipTo, not the
+ * beginning of the whole journal.
  *
  * @api
  */
-interface EventJournalInterface extends \Countable, \SeekableIterator
+interface EventJournalInterface extends \SeekableIterator
 {
     /**
      * Skip all elements of the iterator earlier than date.
@@ -43,7 +49,9 @@ interface EventJournalInterface extends \Countable, \SeekableIterator
      * If an attempt is made to skip past the last element of the iterator, no
      * exception is thrown but the subsequent next() will fail.
      *
-     * @param  integer $date Value that represents an offset in milliseconds from the epoch.
+     * @param  integer $date Value that represents the offset in milliseconds
+     *                       from the epoch. Keep in mind that typical PHP time
+     *                       functions will give you seconds, not milliseconds.
      *
      * @api
      */


### PR DESCRIPTION
i guess jackrabbit with davex is lying anyways when using the getSize method. if we want to keep the countable, we either will lie or have a very good potential of exploding an application by calling count (we would have to recursively fetch all events and then filter them)
