### PR TITLE
adjust to https://java.net/jira/browse/JSR_333-71

### DIFF
--- a/src/PHPCR/NodeInterface.php
+++ b/src/PHPCR/NodeInterface.php
@@ -429,8 +429,8 @@ interface NodeInterface extends ItemInterface, \Traversable
      *    <li>C is accessible through the current Session</li>
      *    <li>If the nameFilter is not null, C must match at least one of the
      *      filter expressions.</li>
-     *   <li>If the typeFilter is not null, C must be isNodeType of at least
-     *      one of the types in typeFilter.
+     *   <li>If the typeFilter is not null, C must be of a node type T that
+     *      matches (by wildcard expansion) at least one of the typeFilters.
      *   </li>
      * </ul>
      *

--- a/src/PHPCR/Observation/EventInterface.php
+++ b/src/PHPCR/Observation/EventInterface.php
@@ -217,8 +217,9 @@ interface EventInterface
      * If this event is of type NODE_ADDED, NODE_REMOVED or NODE_MOVED then
      * this method returns the declared primary node type of the node at (or
      * formerly at) the path returned by getPath(). If this event is of type
-     * PROPERTY_ADDED or PROPERTY_REMOVED then this method returns the declared
-     * primary node type of the parent node of the property affected.
+     * PROPERTY_ADDED, PROPERTY_REMOVED or PROPERTY_CHANGED then this method
+     * returns the declared primary node type of the parent node of the
+     * property affected.
      *
      * @return \PHPCR\NodeType\NodeTypeInterface
      *
@@ -234,8 +235,9 @@ interface EventInterface
      * If this event is of type NODE_ADDED, NODE_REMOVED or NODE_MOVED then
      * this method returns the declared mixin node types of the node at (or
      * formerly at) the path returned by getPath(). If this event is of type
-     * PROPERTY_ADDED or PROPERTY_REMOVED then this method returns the declared
-     * mixin node types of the parent node of the property affected.
+     * PROPERTY_ADDED, PROPERTY_REMOVED or PROPERTY_CHANGED then this method
+     * returns the declared mixin node types of the parent node of the property
+     * affected.
      *
      * @return \PHPCR\NodeType\NodeTypeInterface[]
      *


### PR DESCRIPTION
there where a few inconsistencies in the doc, leading to misinterpretation.
- for the event types, jackalope is already supporting PROPERTY_CHANGED (in violation to the old API, this is now corrected)
- that the types are filtered using globs and not just with isNodeType means we need to adjust jackalope. this however is no break on php code level, the interface stays the same, only semantics change a bit (accepting more parameters than before). i will try to do a PR for that soon.
