### PR TITLE
add getNamespaces method to NamespaceRegistryInterface

### DIFF
--- a/doc/JCR_TO_PHPCR.txt
+++ b/doc/JCR_TO_PHPCR.txt
@@ -195,6 +195,14 @@ separation between Node and Property does make sense, plus allows for things
 like the ItemVisitor.
 
 
+NamespaceRegistry
+*****************
+
+In PHP, arrays are actually hashmaps, that is keys can be any values. This
+makes it natural to have a getNamespaces method with the prefixes as keys and
+the URIs as values, in addition to the getURIs and getPrefixes methods.
+
+
 Import and export
 *****************
 

--- a/src/PHPCR/NamespaceRegistryInterface.php
+++ b/src/PHPCR/NamespaceRegistryInterface.php
@@ -168,6 +168,18 @@ interface NamespaceRegistryInterface extends \Traversable
     public function unregisterNamespaceByURI($uri);
 
     /**
+     * Returns an array with the keys being the namespace prefixes and the
+     * values being the namespaces URIs.
+     *
+     * @return array a hashmap of prefix => namespace uri
+     *
+     * @since 2.1.1
+     *
+     * @api
+     */
+    public function getNamespaces();
+
+    /**
      * Returns an array holding all currently registered namespace prefixes.
      *
      * @return array a string array


### PR DESCRIPTION
This is a BC break for PHPCR implementations, but a small one. I notice that we already added this method in the Jackalope implementation for convenience inside the library (and accidentally started using it elsewhere, too).

Its not strictly semver, but i propose to release this as 2.1.1, as our version naming follows the jcr standard. wdyt?
