### PR TITLE
[POC] Make query constants a final class

### DIFF
--- a/src/PHPCR/Query/QOM/QueryObjectModelConstants.php
+++ b/src/PHPCR/Query/QOM/QueryObjectModelConstants.php
@@ -10,7 +10,7 @@ namespace PHPCR\Query\QOM;
  *
  * @api
  */
-interface QueryObjectModelConstantsInterface
+interface QueryObjectModelConstants
 {
     /**#@+
      * @var string
@@ -89,4 +89,10 @@ interface QueryObjectModelConstantsInterface
     const JCR_ORDER_DESCENDING = 'jcr.order.descending';
 
     /**#@-*/
+
+    public function nameFromValue($value)
+    {
+        // ... 
+        return $value; 
+    }
 }


### PR DESCRIPTION
I am having to serialize allowed query operators to strings and back again, and I notice that PHPCR has classes for constants, e.g. `PropertyType`, but for some reason the class which has the query constants is an interface (`QueryObjectModelConstantsInterface`)

Is there a reason for this?

In particular I want to have access to a `nameFromValue` method as with `PropertyType` and `OnParentVersion`.