### PR TITLE
adjust repository factory to throw exception instead of returning null

### DIFF
--- a/src/PHPCR/ConfigurationException.php
+++ b/src/PHPCR/ConfigurationException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PHPCR;
+
+use InvalidArgumentException;
+
+/**
+ * Exception to throw when the options passed to the factory are invalid.
+ *
+ * @license http://www.apache.org/licenses Apache License Version 2.0, January 2004
+ * @license http://opensource.org/licenses/MIT MIT License
+ */
+class ConfigurationException extends InvalidArgumentException
+{
+}

--- a/src/PHPCR/RepositoryFactoryInterface.php
+++ b/src/PHPCR/RepositoryFactoryInterface.php
@@ -46,9 +46,10 @@ interface RepositoryFactoryInterface
      *      arguments or null if a client wishes to connect to a default
      *      repository.
      *
-     * @return RepositoryInterface a repository instance or null if this
-     *      implementation does not understand the passed parameters
+     * @return RepositoryInterface The repository for these parameters.
      *
+     * @throws ConfigurationException if a required parameter is missing from
+     *      the parameters or an unknown parameter is found in the list.
      * @throws RepositoryException if no suitable repository is found or
      *      another error occurs.
      *


### PR DESCRIPTION
This seems to be a leftover from an oddity of how java service provisioning works. PHP does not do that, so throwing an exception is more explicit and a lot easier to debug.
