### PR TITLE
[WIP] adjustments while implementing ACL

### DIFF
--- a/src/PHPCR/Security/AccessControlManagerInterface.php
+++ b/src/PHPCR/Security/AccessControlManagerInterface.php
@@ -31,7 +31,6 @@ interface AccessControlManagerInterface
      *
      * Note that this method does not return the privileges held by the current
      * session, but rather the privileges supported by the repository.
-     * supports.
      *
      * @param string|null $absPath The absolute path to a node the privileges shall
      *      be fetched of.

--- a/src/PHPCR/Security/PrincipalInterface.php
+++ b/src/PHPCR/Security/PrincipalInterface.php
@@ -20,31 +20,6 @@ namespace PHPCR\Security;
 interface PrincipalInterface
 {
     /**
-     * Compares this principal to the passed object. Returns true if both this
-     * principal and the passed object match the same thing.
-     *
-     * This is necessary, as the same hashCode does not guarantee equality, and
-     * the === operator is too strict, as there could be two instances of the
-     * same principal.
-     *
-     * @param mixed $object
-     *
-     * @return boolean true if the principal passed to the method is the same
-     *      as this object
-     */
-    public function equals($object);
-
-    /**
-     * The hash code must be the same for the same principal.
-     *
-     * However it should be unique inside your application for different
-     * principals.
-     *
-     * @return int a hashcode for this principal.
-     */
-    public function hashCode();
-
-    /**
      * Returns the name of this principal.
      *
      * @return string name of this principal


### PR DESCRIPTION
Principal is something from java.security, so its not jcr specific at all. meaning there is no infrastructure to build principals.

i guess we either need a factory method on the AccessControlManager or provide the trivial implementation in PHPCR directly so people can use `new`.

i wonder how the java side of this actually works, if its using all that fancy stuff to in the end do a string comparison because the principal name and the username used in the jackrabbit connection.
