### PR TITLE
addd missing rep namespace to NamespaceRegistryInterface

### DIFF
--- a/src/PHPCR/NamespaceRegistryInterface.php
+++ b/src/PHPCR/NamespaceRegistryInterface.php
@@ -32,6 +32,11 @@ interface NamespaceRegistryInterface extends \Traversable
     const PREFIX_JCR = "jcr";
 
     /**
+     * A constant for the predefined namespace prefix "rep".
+     */
+    const PREFIX_REP = "rep";
+
+    /**
      * A constant for the predefined namespace prefix "nt".
      * @api
      */
@@ -66,6 +71,12 @@ interface NamespaceRegistryInterface extends \Traversable
      * @api
      */
     const NAMESPACE_JCR = "http://www.jcp.org/jcr/1.0";
+
+    /**
+     * A constant for the predefined namespace mapped by default to the prefix "rep"
+     * @api
+     */
+    const NAMESPACE_REP = "http://www.jcp.org/jcr/rep/1.0";
 
     /**
      * A constant for the predefined namespace mapped by default to the prefix "nt"


### PR DESCRIPTION
The `NamespaceRegistryInterface` class has all the prefixes and URLs for the namespaces registered, but the `rep` namespace was missing. I need that because I have to add it to https://github.com/jackalope/jackalope-doctrine-dbal/blob/2116bbe24e72a9c4cd22eeb6d7e857ce62de094a/src/Jackalope/Transport/DoctrineDBAL/Client.php#L145

Otherwise I cannot register the `jcr:system` and `jcr:versionStorage` node, which have a primary type of `rep:system` resp. `rep:versionStorage`.