### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/PHPCR/Tests/GuestCredentialsTest.php
+++ b/tests/PHPCR/Tests/GuestCredentialsTest.php
@@ -3,9 +3,9 @@ namespace PHPCR\Tests;
 
 use PHPCR\CredentialsInterface;
 use PHPCR\GuestCredentials;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class GuestCredentialsTest extends PHPUnit_Framework_TestCase
+class GuestCredentialsTest extends TestCase
 {
     public function testGuestCredentials()
     {

--- a/tests/PHPCR/Tests/PropertyTypeTest.php
+++ b/tests/PHPCR/Tests/PropertyTypeTest.php
@@ -6,12 +6,12 @@ use DateTime;
 use InvalidArgumentException;
 use PHPCR\PropertyType;
 use PHPCR\ValueFormatException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \PHPCR\PropertyType
  */
-class PropertyTypesTest extends PHPUnit_Framework_TestCase
+class PropertyTypesTest extends TestCase
 {
     /** key = numeric type constant names as defined by api
      *  value = expected value of the TYPENAME_<TYPE> constants

--- a/tests/PHPCR/Tests/SimpleCredentialsTest.php
+++ b/tests/PHPCR/Tests/SimpleCredentialsTest.php
@@ -5,12 +5,12 @@ namespace PHPCR\Tests;
 use InvalidArgumentException;
 use PHPCR\CredentialsInterface;
 use PHPCR\SimpleCredentials;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * a test for the PHPCR\PropertyType class
  */
-class SimpleCredentialsTest extends PHPUnit_Framework_TestCase
+class SimpleCredentialsTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/PHPCR/Tests/Version/OnParentVersionActionTest.php
+++ b/tests/PHPCR/Tests/Version/OnParentVersionActionTest.php
@@ -3,12 +3,12 @@ namespace PHPCR\Tests\Version;
 
 use InvalidArgumentException;
 use PHPCR\Version\OnParentVersionAction;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * a test for the PHPCR\PropertyType class
  */
-class OnParentVersionActionTest extends PHPUnit_Framework_TestCase
+class OnParentVersionActionTest extends TestCase
 {
     /**
      * key = numeric type constant names as defined by api


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).