### PR TITLE
Linking to the correct version of github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ are interchangeable with each other.
 
 *Jackalope separates the content repository logic from the storage backend. Several backend drivers are currently being developed.*
 
-* [Jackalope-Jackrabbit](https://jackalope.github.com/): Mapping requests to a java Jackrabbit instance. To day the most feature complete implementation.
-* [Jackalope-DoctrineDBAL](https://jackalope.github.com/): Storing data in a relational database using the Doctrine Database Abstraction Layer.
+* [Jackalope-Jackrabbit](https://jackalope.github.io/): Mapping requests to a java Jackrabbit instance. To day the most feature complete implementation.
+* [Jackalope-DoctrineDBAL](https://jackalope.github.io/): Storing data in a relational database using the Doctrine Database Abstraction Layer.
 
 The following are a work in progress:
 


### PR DESCRIPTION
The old links seem to be broken.