### PR TITLE
Update QueryObjectModelFactoryInterface literal return type

### DIFF
--- a/src/PHPCR/Query/QOM/QueryObjectModelFactoryInterface.php
+++ b/src/PHPCR/Query/QOM/QueryObjectModelFactoryInterface.php
@@ -608,7 +608,7 @@ interface QueryObjectModelFactoryInterface extends QueryObjectModelConstantsInte
      *
      * @param mixed $literalValue the value
      *
-     * @return mixed the operand
+     * @return LiteralInterface the operand
      *
      * @throws InvalidQueryException if a particular validity test
      *                               is possible on this method, the implementation chooses to perform


### PR DESCRIPTION
Not 100% sure but think this should be Literal object always and can not be endup as mixed? Else maybe as `LiteralInterface<mixed>` if we make a generic out of it but getLiteralValue is typed as string.